### PR TITLE
Fix Hero buttons to have an equal width on mobile

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -61,7 +61,7 @@ const Hero = () => {
 						>
 							<a
 								href="/docs"
-								className="inline-flex items-center justify-center px-8 py-3 text-base font-medium leading-6 text-gray-600 whitespace-no-wrap bg-white border border-gray-200 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:shadow-none"
+								className="inline-flex w-full items-center justify-center px-8 py-3 text-base font-medium leading-6 text-gray-600 whitespace-no-wrap bg-white border border-gray-200 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:shadow-none"
 							>
 								View docs
 							</a>


### PR DESCRIPTION
Hey, just a quick design tweak.

This is the original:
![7F7042AA-FC67-4778-9F0B-B497DBED0F78](https://user-images.githubusercontent.com/47185402/155370340-5b7cc8e2-9a53-49d4-b2aa-976e1dcded5e.jpeg)